### PR TITLE
Refactoring and unit tests for JetMethod

### DIFF
--- a/SharpJet/JetPeer.cs
+++ b/SharpJet/JetPeer.cs
@@ -458,7 +458,7 @@ namespace Hbm.Devices.Jet
 
         private JObject ExecuteMethod(JetMethod method)
         {
-            double timeoutMs = method.getTimeoutMs();
+            double timeoutMs = method.GetTimeoutMs();
             if (timeoutMs < 0.0)
             {
                 throw new ArgumentException("timeoutMs");

--- a/SharpJet/SharpJet.csproj
+++ b/SharpJet/SharpJet.csproj
@@ -63,6 +63,11 @@
     <Compile Include="SocketJetConnection.cs">
       <ExcludeFromStyleCop>False</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="Utils\DisposableBase.cs" />
+    <Compile Include="Utils\ITimer.cs" />
+    <Compile Include="Utils\TimerAdapter.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="WebSocketJetConnection.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/SharpJet/Utils/DisposableBase.cs
+++ b/SharpJet/Utils/DisposableBase.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="FetchId.cs" company="Hottinger Baldwin Messtechnik GmbH">
+﻿// <copyright file="JetPeer.cs" company="Hottinger Baldwin Messtechnik GmbH">
 //
 // SharpJet, a library to communicate with Jet IPC.
 //
@@ -28,36 +28,18 @@
 //
 // </copyright>
 
-namespace SharpJetTests
+namespace Hbm.Devices.Jet.Utils
 {
     using System;
-    using FakeItEasy;
-    using Hbm.Devices.Jet;
-    using Newtonsoft.Json.Linq;
-    using NUnit.Framework;
 
-    [TestFixture]
-    public class JetFetcherTests
+    internal abstract class DisposableBase : IDisposable
     {
-        [Test]
-        public void TestCallFetchCallbackInvokesAction()
+        protected abstract void Dispose(bool disposing);
+
+        public void Dispose()
         {
-            Action<JToken> callback = A.Fake<Action<JToken>>();
-            JetFetcher fetcher = new JetFetcher(callback);
-            JToken token = JToken.FromObject(42);
-
-            fetcher.CallFetchCallback(token);
-
-            A.CallTo(() => callback.Invoke(token)).MustHaveHappened(Repeated.Exactly.Once);
-        }
-
-        [Test]
-        public void TestCallFetchCallbackDoesNothingIfActionIsNull()
-        {
-            JetFetcher fetcher = new JetFetcher(null);
-            JToken token = JToken.FromObject(42);
-
-            Assert.DoesNotThrow(() => fetcher.CallFetchCallback(token));
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/SharpJet/Utils/ITimer.cs
+++ b/SharpJet/Utils/ITimer.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="FetchId.cs" company="Hottinger Baldwin Messtechnik GmbH">
+﻿// <copyright file="JetPeer.cs" company="Hottinger Baldwin Messtechnik GmbH">
 //
 // SharpJet, a library to communicate with Jet IPC.
 //
@@ -28,36 +28,21 @@
 //
 // </copyright>
 
-namespace SharpJetTests
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+
+namespace Hbm.Devices.Jet.Utils
 {
     using System;
-    using FakeItEasy;
-    using Hbm.Devices.Jet;
-    using Newtonsoft.Json.Linq;
-    using NUnit.Framework;
+    using System.Timers;
 
-    [TestFixture]
-    public class JetFetcherTests
+    internal interface ITimer : IDisposable
     {
-        [Test]
-        public void TestCallFetchCallbackInvokesAction()
-        {
-            Action<JToken> callback = A.Fake<Action<JToken>>();
-            JetFetcher fetcher = new JetFetcher(callback);
-            JToken token = JToken.FromObject(42);
+        event ElapsedEventHandler Elapsed;
 
-            fetcher.CallFetchCallback(token);
-
-            A.CallTo(() => callback.Invoke(token)).MustHaveHappened(Repeated.Exactly.Once);
-        }
-
-        [Test]
-        public void TestCallFetchCallbackDoesNothingIfActionIsNull()
-        {
-            JetFetcher fetcher = new JetFetcher(null);
-            JToken token = JToken.FromObject(42);
-
-            Assert.DoesNotThrow(() => fetcher.CallFetchCallback(token));
-        }
+        double Interval { get; set; }
+        void Stop();
+        void Start();
     }
 }

--- a/SharpJet/Utils/TimerAdapter.cs
+++ b/SharpJet/Utils/TimerAdapter.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="FetchId.cs" company="Hottinger Baldwin Messtechnik GmbH">
+﻿// <copyright file="JetPeer.cs" company="Hottinger Baldwin Messtechnik GmbH">
 //
 // SharpJet, a library to communicate with Jet IPC.
 //
@@ -28,36 +28,12 @@
 //
 // </copyright>
 
-namespace SharpJetTests
+
+namespace Hbm.Devices.Jet.Utils
 {
-    using System;
-    using FakeItEasy;
-    using Hbm.Devices.Jet;
-    using Newtonsoft.Json.Linq;
-    using NUnit.Framework;
+    using System.Timers;
 
-    [TestFixture]
-    public class JetFetcherTests
+    internal class TimerAdapter : Timer, ITimer
     {
-        [Test]
-        public void TestCallFetchCallbackInvokesAction()
-        {
-            Action<JToken> callback = A.Fake<Action<JToken>>();
-            JetFetcher fetcher = new JetFetcher(callback);
-            JToken token = JToken.FromObject(42);
-
-            fetcher.CallFetchCallback(token);
-
-            A.CallTo(() => callback.Invoke(token)).MustHaveHappened(Repeated.Exactly.Once);
-        }
-
-        [Test]
-        public void TestCallFetchCallbackDoesNothingIfActionIsNull()
-        {
-            JetFetcher fetcher = new JetFetcher(null);
-            JToken token = JToken.FromObject(42);
-
-            Assert.DoesNotThrow(() => fetcher.CallFetchCallback(token));
-        }
     }
 }

--- a/SharpJetTests/JetMethodTests.cs
+++ b/SharpJetTests/JetMethodTests.cs
@@ -1,0 +1,158 @@
+﻿// <copyright file="ConnectTests.cs" company="Hottinger Baldwin Messtechnik GmbH">
+//
+// SharpJet, a library to communicate with Jet IPC.
+//
+// The MIT License (MIT)
+//
+// Copyright (C) Hottinger Baldwin Messtechnik GmbH
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+// BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+// ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// </copyright>
+
+namespace SharpJetTests
+{
+    using System;
+    using FakeItEasy;
+    using Hbm.Devices.Jet;
+    using Newtonsoft.Json.Linq;
+    using NUnit.Framework;
+    using Hbm.Devices.Jet.Utils;
+
+    [TestFixture]
+    public class JetMethodTests
+    {
+        [Test]
+        public void TestConstructorInitializesTimer()
+        {
+            JetMethod jetMethod = new JetMethod(JetMethod.Info,
+                null,
+                A.Dummy<Action<bool, JToken>>(),
+                1000.0);
+
+            Assert.IsNotNull(jetMethod.RequestTimer as TimerAdapter, "ctor did not initialize a TimerAdapter.");
+        }
+
+        [Test, Parallelizable(ParallelScope.None)]
+        public void TestConstructorDoesNotSetRequestIdIfResponseCallbackIsNull()
+        {
+            JetMethod jetMethod = new JetMethod(JetMethod.Info,
+                null,
+                null, //No callback specified
+                1000.0);
+
+            Assert.AreEqual(0, jetMethod.GetRequestId());
+        }
+
+        [Test, Parallelizable(ParallelScope.None)]
+        public void TestConstructorIncreasesRequestIdIfResponseCallbackIsNotNull()
+        {
+            JetMethod jetMethod = new JetMethod(JetMethod.Info,
+                null,
+                A.Dummy<Action<bool, JToken>>(),
+                1000.0);
+
+            JetMethod nextJetMethod = new JetMethod(JetMethod.Info,
+                null,
+                A.Dummy<Action<bool, JToken>>(),
+                1000.0);
+
+            Assert.AreEqual(1, nextJetMethod.GetRequestId() - jetMethod.GetRequestId());
+        }
+
+        [Test]
+        public void TestConstructorInitializesResponseTimeout()
+        {
+            JetMethod jetMethod = new JetMethod(JetMethod.Info,
+                null,
+                A.Dummy<Action<bool, JToken>>(),
+                1337.42);
+
+            Assert.AreEqual(1337.42, jetMethod.GetTimeoutMs());
+        }
+
+        [Test]
+        public void TestConstructorInitializesJson()
+        {
+            JObject parameter = new JObject();
+            parameter.Add("p1", JToken.FromObject(15));
+            parameter.Add("p2", JToken.FromObject("hello world"));
+            JetMethod jetMethod = new JetMethod(JetMethod.Info,
+                parameter,
+                A.Dummy<Action<bool, JToken>>(),
+                1000.0);
+
+            JObject json = jetMethod.GetJson();
+            Assert.AreEqual((string)json["jsonrpc"], "2.0");
+            Assert.AreEqual((string)json["method"], JetMethod.Info);
+            Assert.AreEqual((int)json["params"]["p1"], 15);
+            Assert.AreEqual((string)json["params"]["p2"], "hello world");
+        }
+
+        [Test]
+        public void TestCallResponseCallbackInvokesActions()
+        {
+            Action<bool, JToken> responseCallback = A.Fake<Action<bool, JToken>>();
+            JetMethod jetMethod = new JetMethod(JetMethod.Info, new JObject(), responseCallback, 1000.0);
+
+            JToken token = JToken.FromObject(15);
+            jetMethod.CallResponseCallback(true, token);
+            jetMethod.CallResponseCallback(false, token);
+            A.CallTo(() => responseCallback.Invoke(true, token)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => responseCallback.Invoke(false, token)).MustHaveHappened(Repeated.Exactly.Once);
+        }
+
+        [Test]
+        public void TestHasResponseCallback()
+        {
+            JetMethod jetMethod1 = new JetMethod(JetMethod.Info,
+                new JObject(), 
+                A.Dummy<Action<bool, JToken>>(), 
+                1000.0);
+
+            JetMethod jetMethod2 = new JetMethod(JetMethod.Info,
+                new JObject(),
+                null,
+                1000.0);
+
+            Assert.IsTrue(jetMethod1.HasResponseCallback(), $"Expected {nameof(jetMethod1)} to have a response callback but received false.");
+            Assert.IsFalse(jetMethod2.HasResponseCallback(), $"Expected {nameof(jetMethod2)} to not have a response callback but received true.");
+        }
+
+        [Test]
+        public void TestDispose()
+        {
+            JetMethod jetMethod = new JetMethod(JetMethod.Info,
+                new JObject(),
+                A.Dummy<Action<bool, JToken>>(),
+                1000.0);
+
+            ITimer timer = A.Fake<ITimer>();
+            jetMethod.RequestTimer = timer;
+            jetMethod.Dispose();
+            
+            //Second call does nothing.
+            jetMethod.Dispose();
+
+            A.CallTo(() => timer.Dispose()).MustHaveHappened(Repeated.Exactly.Once);
+        }
+    }
+}

--- a/SharpJetTests/SharpJetTests.csproj
+++ b/SharpJetTests/SharpJetTests.csproj
@@ -53,6 +53,7 @@
   <ItemGroup>
     <Compile Include="ConnectTests.cs" />
     <Compile Include="JetFetcherTests.cs" />
+    <Compile Include="JetMethodTests.cs" />
     <Compile Include="SetCallbacksTests.cs" />
     <Compile Include="SetTests.cs" />
     <Compile Include="TestJetConnection.cs" />


### PR DESCRIPTION
Introduced ITimer interface to remove strong coupling to System.Timers.Timer.
RequestTimer now has an internal setter that can be utilized in unit tests.
Timer implements IDisposable therefore JetMethod should implement IDisposable as well in order to call dispose on the timer.
Dispose pattern extracted in abstract base.